### PR TITLE
Faster loads, correct stickiness, and descriptive analytics

### DIFF
--- a/notebooks/attribute_analysis.py
+++ b/notebooks/attribute_analysis.py
@@ -1,0 +1,338 @@
+"""Analysis of descriptive telemetry attributes: versions, deployments, browsers, etc.
+
+These power the standalone descriptive charts and the sidebar segmentation. All
+functions operate on the events dataframe produced by ``data_loader`` (which carries
+``UserID`` plus the descriptive columns) unless stated otherwise.
+"""
+
+from datetime import timedelta
+
+import polars as pl
+from config import BASELINE
+
+# Ordered deployment-size buckets (by RunningContainers) for consistent chart ordering.
+CONTAINER_BUCKETS = ["0", "1-5", "6-20", "21-50", "51-200", "200+"]
+
+
+def _week_index(col: pl.Expr) -> pl.Expr:
+    """Whole weeks between ``col`` and the cohort baseline (matches cohort_analysis)."""
+    return ((col - pl.lit(BASELINE)) / timedelta(weeks=1)).cast(pl.Int64)
+
+
+def _week_date(col: pl.Expr) -> pl.Expr:
+    """Convert a week index back to the date of that week's start."""
+    return pl.lit(BASELINE) + col.cast(pl.Int64) * pl.duration(weeks=1)
+
+
+# Feature-flag columns surfaced in adoption charts and segmentation.
+FEATURE_FLAGS = [
+    "HasActions",
+    "HasHostname",
+    "HasCustomAddress",
+    "HasCustomBase",
+    "HasShell",
+]
+
+
+def container_bucket_expr(col: pl.Expr) -> pl.Expr:
+    """Bucket a RunningContainers count into an ordered deployment-size band."""
+    return (
+        pl.when(col.is_null())
+        .then(pl.lit("Unknown"))
+        .when(col == 0)
+        .then(pl.lit("0"))
+        .when(col <= 5)
+        .then(pl.lit("1-5"))
+        .when(col <= 20)
+        .then(pl.lit("6-20"))
+        .when(col <= 50)
+        .then(pl.lit("21-50"))
+        .when(col <= 200)
+        .then(pl.lit("51-200"))
+        .otherwise(pl.lit("200+"))
+    )
+
+
+def browser_family_expr(col: pl.Expr) -> pl.Expr:
+    """Map a raw user-agent string to a browser family.
+
+    Order matters: Edge/Opera advertise "Chrome", and Chrome advertises "Safari", so
+    the more specific tokens are checked first.
+    """
+    return (
+        pl.when(col.is_null())
+        .then(pl.lit("Unknown"))
+        .when(col.str.contains("Edg/") | col.str.contains("Edge/"))
+        .then(pl.lit("Edge"))
+        .when(col.str.contains("OPR/") | col.str.contains("Opera"))
+        .then(pl.lit("Opera"))
+        .when(col.str.contains("Firefox/"))
+        .then(pl.lit("Firefox"))
+        .when(col.str.contains("Chrome/"))
+        .then(pl.lit("Chrome"))
+        .when(col.str.contains("Safari/"))
+        .then(pl.lit("Safari"))
+        .otherwise(pl.lit("Other"))
+    )
+
+
+def os_family_expr(col: pl.Expr) -> pl.Expr:
+    """Map a raw user-agent string to an OS family.
+
+    Order matters: Android and iPad user-agents also contain "Linux"/"Mac OS X", so
+    the mobile platforms are checked before the desktop ones.
+    """
+    return (
+        pl.when(col.is_null())
+        .then(pl.lit("Unknown"))
+        .when(col.str.contains("Windows"))
+        .then(pl.lit("Windows"))
+        .when(col.str.contains("Android"))
+        .then(pl.lit("Android"))
+        .when(col.str.contains("iPhone") | col.str.contains("iPad") | col.str.contains("iPod"))
+        .then(pl.lit("iOS"))
+        .when(col.str.contains("Mac OS X") | col.str.contains("Macintosh"))
+        .then(pl.lit("macOS"))
+        .when(col.str.contains("Linux") | col.str.contains("X11"))
+        .then(pl.lit("Linux"))
+        .otherwise(pl.lit("Other"))
+    )
+
+
+def calculate_install_attributes(df: pl.DataFrame) -> pl.DataFrame:
+    """Collapse the events to one row per install with its latest reported attributes.
+
+    Used both for the deployment-size / browser distributions and as the lookup table
+    that backs sidebar segmentation. Attributes are taken from each install's most
+    recent event so segmentation reflects its current state.
+
+    Args:
+        df: Events dataframe with ``UserID``, ``CreatedAt``, and descriptive columns.
+
+    Returns:
+        pl.DataFrame: One row per ``UserID`` with derived ``container_bucket``,
+        ``browser_family``, and ``os_family`` columns.
+    """
+    latest = df.sort("CreatedAt").group_by("UserID").last()
+    return latest.with_columns(
+        container_bucket_expr(pl.col("RunningContainers")).alias("container_bucket"),
+        browser_family_expr(pl.col("Browser")).alias("browser_family"),
+        os_family_expr(pl.col("Browser")).alias("os_family"),
+    )
+
+
+def filter_installs(install_attrs: pl.DataFrame, selections: dict) -> pl.Series:
+    """Return the UserIDs whose install attributes match every active selection.
+
+    Selections AND across attributes and OR within each attribute's value list. An
+    empty (or missing) value list places no constraint on that attribute.
+
+    Args:
+        install_attrs: Output of :func:`calculate_install_attributes`.
+        selections: Mapping of attribute column -> list of allowed values.
+
+    Returns:
+        pl.Series: Matching ``UserID`` values.
+    """
+    matched = install_attrs
+    for column, allowed in selections.items():
+        if allowed:
+            matched = matched.filter(pl.col(column).is_in(allowed))
+    return matched["UserID"]
+
+
+def calculate_version_adoption(df: pl.DataFrame, top_n: int = 8) -> pl.DataFrame:
+    """Weekly share of active installs running each version (top N, rest as 'Other').
+
+    Args:
+        df: Events with ``UserID``, ``current_week``, and ``Version``.
+        top_n: Number of most-common versions to keep distinct.
+
+    Returns:
+        pl.DataFrame: ``current_week``, ``version``, ``installs``, ``share``, ``week_date``.
+    """
+    weekly = df.group_by(["current_week", "Version"]).agg(
+        pl.col("UserID").n_unique().alias("installs")
+    )
+    top = (
+        weekly.group_by("Version")
+        .agg(pl.col("installs").sum().alias("total"))
+        .sort("total", descending=True)
+        .head(top_n)["Version"]
+        .to_list()
+    )
+    weekly = (
+        weekly.with_columns(
+            pl.when(pl.col("Version").is_in(top))
+            .then(pl.col("Version"))
+            .otherwise(pl.lit("Other"))
+            .alias("version")
+        )
+        .group_by(["current_week", "version"])
+        .agg(pl.col("installs").sum().alias("installs"))
+    )
+    totals = df.group_by("current_week").agg(pl.col("UserID").n_unique().alias("active"))
+    return (
+        weekly.join(totals, on="current_week")
+        .with_columns(
+            (pl.col("installs") / pl.col("active")).alias("share"),
+            _week_date(pl.col("current_week")).alias("week_date"),
+        )
+        .sort(["current_week", "version"])
+    )
+
+
+def calculate_new_installs(start_df: pl.DataFrame) -> pl.DataFrame:
+    """Weekly new installs and launch volume from the start (app-launch) beacons.
+
+    Args:
+        start_df: Start beacons with ``UserID`` and ``CreatedAt``.
+
+    Returns:
+        pl.DataFrame: ``week``, ``new_installs`` (installs launching for the first time
+        that week), ``active_installs``, ``launches`` (total beacons), ``week_date``.
+    """
+    starts = start_df.with_columns(_week_index(pl.col("CreatedAt")).alias("week"))
+    first_week = (
+        starts.group_by("UserID")
+        .agg(pl.col("week").min().alias("first_week"))
+        .group_by("first_week")
+        .agg(pl.len().alias("new_installs"))
+    )
+    weekly = starts.group_by("week").agg(
+        pl.col("UserID").n_unique().alias("active_installs"),
+        pl.len().alias("launches"),
+    )
+    return (
+        weekly.join(first_week, left_on="week", right_on="first_week", how="left")
+        .with_columns(pl.col("new_installs").fill_null(0))
+        .with_columns(_week_date(pl.col("week")).alias("week_date"))
+        .sort("week")
+    )
+
+
+def calculate_deployment_scale(install_attrs: pl.DataFrame) -> pl.DataFrame:
+    """Distribution of installs across deployment-size buckets.
+
+    Args:
+        install_attrs: Output of :func:`calculate_install_attributes`.
+
+    Returns:
+        pl.DataFrame: ``container_bucket``, ``installs``, ``share`` (bucket-ordered).
+    """
+    order = {bucket: i for i, bucket in enumerate([*CONTAINER_BUCKETS, "Unknown"])}
+    total = install_attrs.height
+    dist = install_attrs.group_by("container_bucket").agg(pl.len().alias("installs"))
+    return (
+        dist.with_columns(
+            (pl.col("installs") / total).alias("share"),
+            pl.col("container_bucket").replace_strict(order, default=len(order)).alias("_order"),
+        )
+        .sort("_order")
+        .drop("_order")
+    )
+
+
+def calculate_auth_mix(df: pl.DataFrame) -> pl.DataFrame:
+    """Weekly share of active installs by auth provider.
+
+    Args:
+        df: Events with ``UserID``, ``current_week``, and ``AuthProvider``.
+
+    Returns:
+        pl.DataFrame: ``current_week``, ``AuthProvider``, ``installs``, ``share``, ``week_date``.
+    """
+    weekly = df.group_by(["current_week", "AuthProvider"]).agg(
+        pl.col("UserID").n_unique().alias("installs")
+    )
+    totals = df.group_by("current_week").agg(pl.col("UserID").n_unique().alias("active"))
+    return (
+        weekly.join(totals, on="current_week")
+        .with_columns(
+            (pl.col("installs") / pl.col("active")).alias("share"),
+            _week_date(pl.col("current_week")).alias("week_date"),
+        )
+        .sort(["current_week", "AuthProvider"])
+    )
+
+
+def calculate_concurrent_clients(df: pl.DataFrame) -> pl.DataFrame:
+    """Weekly average and maximum concurrent browser clients per install.
+
+    Each install's weekly peak Clients is taken first, then averaged across installs so
+    busy installs don't dominate via beacon count.
+
+    Args:
+        df: Events with ``UserID``, ``current_week``, and ``Clients``.
+
+    Returns:
+        pl.DataFrame: ``current_week``, ``avg_clients``, ``max_clients``, ``week_date``.
+    """
+    peaks = df.group_by(["UserID", "current_week"]).agg(pl.col("Clients").max().alias("peak"))
+    return (
+        peaks.group_by("current_week")
+        .agg(
+            pl.col("peak").mean().alias("avg_clients"),
+            pl.col("peak").max().alias("max_clients"),
+        )
+        .with_columns(_week_date(pl.col("current_week")).alias("week_date"))
+        .sort("current_week")
+    )
+
+
+def calculate_feature_adoption(df: pl.DataFrame) -> pl.DataFrame:
+    """Weekly share of active installs that have each feature flag enabled.
+
+    A null flag (older data that predates the feature) counts as not adopted.
+
+    Args:
+        df: Events with ``UserID``, ``current_week``, and the feature-flag columns.
+
+    Returns:
+        pl.DataFrame: ``current_week``, ``feature``, ``installs``, ``adoption``, ``week_date``.
+    """
+    per_install = df.group_by(["UserID", "current_week"]).agg(
+        [pl.col(flag).fill_null(False).max().alias(flag) for flag in FEATURE_FLAGS]
+    )
+    totals = per_install.group_by("current_week").agg(pl.len().alias("installs"))
+    long = per_install.unpivot(
+        index=["UserID", "current_week"],
+        on=FEATURE_FLAGS,
+        variable_name="feature",
+        value_name="enabled",
+    )
+    return (
+        long.group_by(["current_week", "feature"])
+        .agg(pl.col("enabled").sum().alias("enabled_installs"))
+        .join(totals, on="current_week")
+        .with_columns(
+            (pl.col("enabled_installs") / pl.col("installs")).alias("adoption"),
+            _week_date(pl.col("current_week")).alias("week_date"),
+        )
+        .sort(["current_week", "feature"])
+    )
+
+
+def _share_distribution(install_attrs: pl.DataFrame, column: str) -> pl.DataFrame:
+    total = install_attrs.height
+    return (
+        install_attrs.group_by(column)
+        .agg(pl.len().alias("installs"))
+        .with_columns((pl.col("installs") / total).alias("share"))
+        .sort("installs", descending=True)
+    )
+
+
+def calculate_browser_mix(install_attrs: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Distribution of installs by browser family and by OS family.
+
+    Args:
+        install_attrs: Output of :func:`calculate_install_attributes`.
+
+    Returns:
+        tuple: ``(browser_df, os_df)``, each with ``installs`` and ``share``.
+    """
+    return (
+        _share_distribution(install_attrs, "browser_family"),
+        _share_distribution(install_attrs, "os_family"),
+    )

--- a/notebooks/dashboard.py
+++ b/notebooks/dashboard.py
@@ -1,13 +1,31 @@
-"""Streamlit dashboard for Dozzle retention analysis."""
+"""Streamlit dashboard for Dozzle retention and usage analysis."""
 
+import polars as pl
 import streamlit as st
+from attribute_analysis import (
+    CONTAINER_BUCKETS,
+    FEATURE_FLAGS,
+    calculate_auth_mix,
+    calculate_browser_mix,
+    calculate_concurrent_clients,
+    calculate_deployment_scale,
+    calculate_feature_adoption,
+    calculate_install_attributes,
+    calculate_new_installs,
+    calculate_version_adoption,
+    filter_installs,
+)
 from cohort_analysis import (
     calculate_cohort_retention,
     compute_cohort_data,
     prepare_retention_matrix,
 )
 from config import COHORT_DETAILS_HEAD, PAGE_LAYOUT, PAGE_TITLE
-from data_loader import load_and_process_data
+from data_loader import (
+    calculate_identity_quality,
+    load_and_process_data,
+    load_start_beacons,
+)
 from engagement_analysis import (
     calculate_cohort_engagement_metrics,
     calculate_engagement_depth,
@@ -16,64 +34,189 @@ from engagement_analysis import (
 )
 from usage_analysis import calculate_usage_frequency
 from visualizations import (
+    display_auth_mix_analysis,
+    display_browser_mix_analysis,
     display_cohort_engagement_analysis,
+    display_concurrent_clients_analysis,
+    display_deployment_scale_analysis,
     display_engagement_depth_analysis,
+    display_feature_adoption_analysis,
+    display_new_installs_analysis,
     display_retention_heatmap,
     display_stickiness_analysis,
     display_usage_frequency_analysis,
     display_user_lifecycle_analysis,
+    display_version_adoption_analysis,
 )
 
-# Configuration
+# Telemetry columns present in the schema but empty/zero across the entire history.
+DEAD_TELEMETRY_COLUMNS = [
+    "ServerVersion",
+    "SubCommand",
+    "Mode (swarm)",
+    "RemoteAgents",
+    "RemoteClients",
+    "FilterLength",
+    "IsSwarmMode",
+]
+
 st.set_page_config(page_title=PAGE_TITLE, layout=PAGE_LAYOUT)
+
+
+@st.cache_resource(ttl=3600)
+def get_events() -> pl.DataFrame:
+    """Load the events beacons once. Cached as a large read-only resource."""
+    return load_and_process_data()
+
+
+@st.cache_resource(ttl=3600)
+def get_cohort_full() -> pl.DataFrame:
+    """Cohort-computed events for the unsegmented (whole-population) view."""
+    return compute_cohort_data(get_events())
+
+
+@st.cache_resource(ttl=3600)
+def get_install_attributes() -> pl.DataFrame:
+    """Per-install latest attributes, used for distributions and segmentation."""
+    return calculate_install_attributes(get_events())
+
+
+@st.cache_resource(ttl=3600)
+def get_starts() -> pl.DataFrame:
+    """Start (app-launch) beacons for new-install analysis."""
+    return load_start_beacons()
+
+
+def _options(attrs: pl.DataFrame, column: str, limit: int | None = None) -> list:
+    counts = attrs[column].drop_nulls().value_counts(sort=True)[column].to_list()
+    return counts[:limit] if limit else counts
+
+
+def build_segment_selections(attrs: pl.DataFrame) -> dict:
+    """Render sidebar segmentation controls and return the active selections."""
+    st.sidebar.header("Segment installs")
+    st.sidebar.caption("Filters re-slice every chart by install attributes.")
+
+    selections: dict = {}
+    version = st.sidebar.multiselect("Version", _options(attrs, "Version", limit=30))
+    if version:
+        selections["Version"] = version
+
+    auth = st.sidebar.multiselect("Auth provider", _options(attrs, "AuthProvider"))
+    if auth:
+        selections["AuthProvider"] = auth
+
+    size = st.sidebar.multiselect("Deployment size", CONTAINER_BUCKETS)
+    if size:
+        selections["container_bucket"] = size
+
+    browser = st.sidebar.multiselect("Browser", _options(attrs, "browser_family"))
+    if browser:
+        selections["browser_family"] = browser
+
+    os_family = st.sidebar.multiselect("OS", _options(attrs, "os_family"))
+    if os_family:
+        selections["os_family"] = os_family
+
+    require = st.sidebar.multiselect("Require features", FEATURE_FLAGS)
+    for flag in require:
+        selections[flag] = [True]
+
+    return selections
 
 
 def main() -> None:
     """Main dashboard function."""
-    st.title("Cohort Retention Analysis")
+    st.title("Dozzle Usage & Retention Analysis")
 
-    # Load and process data
     with st.spinner("Loading and processing data..."):
-        df = load_and_process_data()
-        df = compute_cohort_data(df)
+        events = get_events()
+        attrs = get_install_attributes()
 
-    # Calculate cohort retention
-    with st.spinner("Calculating cohort retention rates..."):
+    selections = build_segment_selections(attrs)
+    if selections:
+        ids = filter_installs(attrs, selections)
+        if ids.len() == 0:
+            st.warning("No installs match the current segment. Adjust the sidebar filters.")
+            return
+        id_set = ids.implode()  # implode -> unambiguous membership test (polars #22149)
+        df = compute_cohort_data(events.filter(pl.col("UserID").is_in(id_set)))
+        attrs = attrs.filter(pl.col("UserID").is_in(id_set))
+        starts = get_starts().filter(pl.col("UserID").is_in(id_set))
+        st.sidebar.success(f"Segment: {ids.len():,} installs")
+    else:
+        df = get_cohort_full()
+        starts = get_starts()
+
+    overview, retention_tab, usage_tab, lifecycle_tab, deploy_tab, version_tab = st.tabs(
+        ["Overview", "Retention", "Usage & Stickiness", "Lifecycle", "Deployments", "Versions"]
+    )
+
+    quality = calculate_identity_quality(df)
+    new_installs = calculate_new_installs(starts)
+    stickiness_df, stickiness_stats = calculate_stickiness_metrics(df)
+
+    with overview:
+        _render_overview(quality, stickiness_stats, new_installs)
+
+    with retention_tab:
         cohort_counts = calculate_cohort_retention(df)
-        retention = prepare_retention_matrix(cohort_counts)
+        display_retention_heatmap(prepare_retention_matrix(cohort_counts))
+        with st.expander(f"Show top {COHORT_DETAILS_HEAD} rows"):
+            st.dataframe(cohort_counts.head(COHORT_DETAILS_HEAD))
+        display_cohort_engagement_analysis(calculate_cohort_engagement_metrics(df))
 
-    # Display cohort retention heatmap
-    with st.spinner("Generating retention heatmap..."):
-        display_retention_heatmap(retention)
-
-    # Show data details
-    with st.expander(f"Show top {COHORT_DETAILS_HEAD} rows"):
-        st.dataframe(cohort_counts.head(COHORT_DETAILS_HEAD))
-
-    # Calculate and display usage frequency analysis
-    with st.spinner("Calculating usage frequency metrics..."):
+    with usage_tab:
         usage_frequency, overall_avg = calculate_usage_frequency(df)
         display_usage_frequency_analysis(usage_frequency, overall_avg)
-
-    # Calculate and display user lifecycle metrics
-    with st.spinner("Calculating user lifecycle metrics..."):
-        lifecycle_df = calculate_user_lifecycle_metrics(df)
-        display_user_lifecycle_analysis(lifecycle_df)
-
-    # Calculate and display stickiness metrics
-    with st.spinner("Calculating stickiness metrics..."):
-        stickiness_df, stickiness_stats = calculate_stickiness_metrics(df)
         display_stickiness_analysis(stickiness_df, stickiness_stats)
+        display_concurrent_clients_analysis(calculate_concurrent_clients(df))
+        display_engagement_depth_analysis(calculate_engagement_depth(df))
 
-    # Calculate and display engagement depth
-    with st.spinner("Calculating engagement depth metrics..."):
-        engagement_depth_df = calculate_engagement_depth(df)
-        display_engagement_depth_analysis(engagement_depth_df)
+    with lifecycle_tab:
+        display_user_lifecycle_analysis(calculate_user_lifecycle_metrics(df))
+        display_new_installs_analysis(new_installs)
 
-    # Calculate and display cohort engagement metrics
-    with st.spinner("Calculating cohort engagement metrics..."):
-        cohort_engagement_df = calculate_cohort_engagement_metrics(df)
-        display_cohort_engagement_analysis(cohort_engagement_df)
+    with deploy_tab:
+        display_deployment_scale_analysis(calculate_deployment_scale(attrs))
+        display_auth_mix_analysis(calculate_auth_mix(df))
+        browser_df, os_df = calculate_browser_mix(attrs)
+        display_browser_mix_analysis(browser_df, os_df)
+
+    with version_tab:
+        display_version_adoption_analysis(calculate_version_adoption(df))
+        display_feature_adoption_analysis(calculate_feature_adoption(df))
+
+
+def _render_overview(quality: dict, stickiness_stats: dict, new_installs: pl.DataFrame) -> None:
+    """Top-level KPIs plus data-quality caveats."""
+    st.header("Overview")
+
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Installs", f"{quality['total_users']:,}")
+    col2.metric("Current WAU", f"{stickiness_stats['current_wau']:,}")
+    col3.metric("Current MAU (4-week)", f"{stickiness_stats['current_mau']:,}")
+    if new_installs.height:
+        col4.metric("New Installs (Last Week)", f"{new_installs['new_installs'][-1]:,}")
+
+    st.caption(
+        f"{quality['total_users']:,} installs · {quality['total_rows']:,} events. "
+        f"{quality['ip_user_pct']:.1%} of installs are identified by IP address "
+        "(no ServerID); their retention and churn are approximate, since IPs change "
+        "over time and are shared behind NAT."
+    )
+
+    with st.expander("Data quality notes"):
+        st.markdown(
+            f"- **IP-identified installs:** {quality['ip_users']:,} of {quality['total_users']:,} "
+            f"({quality['ip_user_pct']:.1%}) lack a stable ServerID and fall back to a hashed "
+            "RemoteIP. These inflate new-user/churn counts and deflate retention.\n"
+            "- **Engagement = beacon activity**, not feature use: `events` are periodic "
+            "telemetry beacons, so per-user event counts mostly reflect uptime/frequency.\n"
+            "- **Unused telemetry:** these columns are collected but empty/zero across the "
+            f"entire history, so nothing can be charted from them yet: "
+            f"{', '.join('`' + c + '`' for c in DEAD_TELEMETRY_COLUMNS)}."
+        )
 
 
 if __name__ == "__main__":

--- a/notebooks/data_loader.py
+++ b/notebooks/data_loader.py
@@ -1,46 +1,115 @@
 """Data loading and processing utilities for retention analysis."""
 
-from pathlib import Path
+from typing import cast
 
 import polars as pl
 from config import DATA_PATH
 
+# Explicit read schema: exactly the columns we analyse/chart. Listing them here means
+# the scan reads only these (projection pushdown), tolerates schema drift across files
+# (HasShell only exists in newer files -> inserted as null for old ones), and silently
+# ignores the always-empty "dead" telemetry columns (ServerVersion, SubCommand, Mode,
+# RemoteAgents/Clients, FilterLength, IsSwarmMode) instead of carrying them around.
+_SCAN_SCHEMA = {
+    "Name": pl.String,
+    "CreatedAt": pl.Datetime("ns", "UTC"),
+    "ServerID": pl.String,
+    "RemoteIP": pl.String,
+    "Version": pl.String,
+    "RunningContainers": pl.Int64,
+    "AuthProvider": pl.String,
+    "Clients": pl.Int64,
+    "Browser": pl.String,
+    "HasActions": pl.Boolean,
+    "HasHostname": pl.Boolean,
+    "HasCustomAddress": pl.Boolean,
+    "HasCustomBase": pl.Boolean,
+    "HasShell": pl.Boolean,
+}
 
-def load_and_process_data() -> pl.DataFrame:
-    """Load parquet files and perform initial data processing.
+# Raw identity columns dropped once UserID/id_from_ip are derived from them.
+_IDENTITY_COLUMNS = ["ServerID", "RemoteIP"]
 
-    Returns:
-        pl.DataFrame: Processed dataframe with UserID and cleaned columns.
-    """
-    data_path = Path(DATA_PATH)
-    parquet_files = sorted(data_path.parent.glob(data_path.name))
-    df = pl.concat([pl.read_parquet(file) for file in parquet_files], how="diagonal")
 
-    # Filter and clean data
-    df = (
-        df.filter(df["Name"] == "events")
+def _scan(data_glob: str) -> pl.LazyFrame:
+    """Lazily scan the daily parquet files and derive the stable identity columns."""
+    return (
+        pl.scan_parquet(
+            data_glob,
+            schema=_SCAN_SCHEMA,
+            missing_columns="insert",
+            extra_columns="ignore",
+        )
         .with_columns(
-            pl.when(pl.col("ServerID").is_null() | (pl.col("ServerID") == ""))
+            (pl.col("ServerID").is_null() | (pl.col("ServerID") == "")).alias("id_from_ip")
+        )
+        .with_columns(
+            pl.when(pl.col("id_from_ip"))
             .then(pl.col("RemoteIP").hash())
             .otherwise(pl.col("ServerID").hash())
             .alias("UserID")
         )
-        .drop(
-            [
-                "RemoteIP",
-                "HasHostname",
-                "FilterLength",
-                "Clients",
-                "HasActions",
-                "Browser",
-                "ServerID",
-                "HasCustomAddress",
-                "HasCustomBase",
-                "IsSwarmMode",
-                "RemoteClients",
-                "RemoteAgents",
-            ]
-        )
     )
 
-    return df
+
+def load_and_process_data(data_glob: str = DATA_PATH) -> pl.DataFrame:
+    """Load the ``events`` beacons with the descriptive columns used for analysis.
+
+    Uses a lazy scan so the ``Name == "events"`` predicate and the column projection are
+    pushed into the parquet read instead of loading every row/column of every file into
+    memory first. Keeps the descriptive columns (version, deployment size, auth, clients,
+    browser, feature flags) for charting and segmentation, drops the raw identity columns
+    once ``UserID``/``id_from_ip`` are derived, and flags IP-derived identities.
+
+    Args:
+        data_glob: Glob pattern matching the daily parquet files.
+
+    Returns:
+        pl.DataFrame: Events with UserID, id_from_ip, and descriptive columns.
+    """
+    lazy = _scan(data_glob).filter(pl.col("Name") == "events").drop(_IDENTITY_COLUMNS, strict=False)
+    return cast(pl.DataFrame, lazy.collect())
+
+
+def load_start_beacons(data_glob: str = DATA_PATH) -> pl.DataFrame:
+    """Load the ``start`` (app-launch) beacons for new-install analysis.
+
+    These are a distinct ~45% of rows that the events pipeline filters out; they are a
+    cleaner launch/relaunch signal than inferring activation from periodic events.
+
+    Args:
+        data_glob: Glob pattern matching the daily parquet files.
+
+    Returns:
+        pl.DataFrame: Launch beacons with ``UserID`` and ``CreatedAt``.
+    """
+    lazy = _scan(data_glob).filter(pl.col("Name") == "start").select("UserID", "CreatedAt")
+    return cast(pl.DataFrame, lazy.collect())
+
+
+def calculate_identity_quality(df: pl.DataFrame) -> dict:
+    """Report how much of the data relies on the RemoteIP identity fallback.
+
+    UserIDs derived from RemoteIP (no ServerID) are unstable across IP changes and
+    collapse users behind shared IPs, distorting every cohort/retention metric. This
+    surfaces the magnitude so the dashboard can caveat the numbers.
+
+    Args:
+        df: Dataframe with ``UserID`` and ``id_from_ip`` columns.
+
+    Returns:
+        dict: Row/user counts and the IP-derived fraction of each.
+    """
+    total_rows = df.height
+    ip_rows = int(df.select(pl.col("id_from_ip").sum()).item())
+    total_users = int(df.select(pl.col("UserID").n_unique()).item())
+    ip_users = int(df.filter(pl.col("id_from_ip")).select(pl.col("UserID").n_unique()).item())
+
+    return {
+        "total_rows": total_rows,
+        "ip_rows": ip_rows,
+        "ip_row_pct": ip_rows / total_rows if total_rows else 0.0,
+        "total_users": total_users,
+        "ip_users": ip_users,
+        "ip_user_pct": ip_users / total_users if total_users else 0.0,
+    }

--- a/notebooks/engagement_analysis.py
+++ b/notebooks/engagement_analysis.py
@@ -83,13 +83,25 @@ def calculate_stickiness_metrics(df: pl.DataFrame) -> tuple[pl.DataFrame, dict]:
         .sort("current_week")
     )
 
-    # Calculate 4-week rolling active users (approximation of MAU)
-    wau = wau.with_columns(
-        pl.col("wau").rolling_max(window_size=4, min_samples=1).alias("mau_rolling_max")
+    # Calculate true MAU: distinct users over a trailing 4-week window. Each active
+    # (user, week) contributes to the MAU of that week and the next three, so distinct
+    # users per target week is exactly the trailing-4-week unique count.
+    mau = (
+        df.select("UserID", "current_week")
+        .unique()
+        .with_columns(
+            pl.int_ranges(pl.col("current_week"), pl.col("current_week") + 4).alias("window_week")
+        )
+        .explode("window_week")
+        .group_by("window_week")
+        .agg(pl.col("UserID").n_unique().alias("mau"))
     )
+    wau = wau.join(mau, left_on="current_week", right_on="window_week", how="left")
 
     # Calculate stickiness ratio (WAU / MAU)
-    wau = wau.with_columns((pl.col("wau") / pl.col("mau_rolling_max")).alias("stickiness_ratio"))
+    wau = wau.with_columns((pl.col("wau") / pl.col("mau")).alias("stickiness_ratio")).sort(
+        "current_week"
+    )
 
     # Add week date
     wau = wau.with_columns(
@@ -102,7 +114,7 @@ def calculate_stickiness_metrics(df: pl.DataFrame) -> tuple[pl.DataFrame, dict]:
     summary_stats = {
         "avg_stickiness": wau.select(pl.col("stickiness_ratio").mean())[0, 0],
         "current_wau": wau.select(pl.col("wau").tail(1))[0, 0],
-        "current_mau": wau.select(pl.col("mau_rolling_max").tail(1))[0, 0],
+        "current_mau": wau.select(pl.col("mau").tail(1))[0, 0],
     }
 
     return wau, summary_stats

--- a/notebooks/tests/conftest.py
+++ b/notebooks/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Make the flat-imported notebook modules importable from tests."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/notebooks/tests/test_attribute_analysis.py
+++ b/notebooks/tests/test_attribute_analysis.py
@@ -1,0 +1,271 @@
+"""Tests for descriptive-attribute analysis (versions, deployments, browsers, etc.)."""
+
+from datetime import UTC, datetime
+
+import polars as pl
+from attribute_analysis import (
+    browser_family_expr,
+    calculate_auth_mix,
+    calculate_browser_mix,
+    calculate_concurrent_clients,
+    calculate_deployment_scale,
+    calculate_feature_adoption,
+    calculate_install_attributes,
+    calculate_new_installs,
+    calculate_version_adoption,
+    filter_installs,
+    os_family_expr,
+)
+
+
+def _dt(day: int) -> datetime:
+    return datetime(2025, 1, day, tzinfo=UTC)
+
+
+CHROME_WIN = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+)
+EDGE_WIN = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0"
+)
+FIREFOX_WIN = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0"
+SAFARI_MAC = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+)
+SAFARI_IOS = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+)
+CHROME_ANDROID = (
+    "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+)
+CHROME_LINUX = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+)
+
+
+def test_browser_and_os_families_resolve_with_correct_priority():
+    """Edge/Android/iOS must win over the Chrome/Linux/macOS substrings they contain."""
+    df = pl.DataFrame(
+        {
+            "Browser": [
+                CHROME_WIN,
+                EDGE_WIN,
+                FIREFOX_WIN,
+                SAFARI_MAC,
+                SAFARI_IOS,
+                CHROME_ANDROID,
+                CHROME_LINUX,
+                None,
+            ]
+        }
+    )
+
+    out = df.with_columns(
+        browser_family_expr(pl.col("Browser")).alias("browser"),
+        os_family_expr(pl.col("Browser")).alias("os"),
+    )
+
+    assert out["browser"].to_list() == [
+        "Chrome",
+        "Edge",
+        "Firefox",
+        "Safari",
+        "Safari",
+        "Chrome",
+        "Chrome",
+        "Unknown",
+    ]
+    assert out["os"].to_list() == [
+        "Windows",
+        "Windows",
+        "Windows",
+        "macOS",
+        "iOS",
+        "Android",
+        "Linux",
+        "Unknown",
+    ]
+
+
+def test_install_attributes_uses_latest_value_per_install():
+    """Each install collapses to one row holding its most recent reported attributes."""
+    df = pl.DataFrame(
+        {
+            "UserID": [1, 1, 2],
+            "CreatedAt": [_dt(1), _dt(5), _dt(1)],
+            "Version": ["v1", "v2", "v9"],
+            "AuthProvider": ["none", "simple", "none"],
+            "RunningContainers": [3, 30, 0],
+            "Browser": [CHROME_WIN, FIREFOX_WIN, None],
+        }
+    )
+
+    attrs = calculate_install_attributes(df)
+    a1 = attrs.filter(pl.col("UserID") == 1).row(0, named=True)
+    a2 = attrs.filter(pl.col("UserID") == 2).row(0, named=True)
+
+    assert attrs.height == 2
+    assert a1["Version"] == "v2"  # latest by CreatedAt
+    assert a1["AuthProvider"] == "simple"
+    assert a1["container_bucket"] == "21-50"
+    assert a1["browser_family"] == "Firefox"
+    assert a2["container_bucket"] == "0"
+    assert a2["browser_family"] == "Unknown"
+
+
+def test_filter_installs_matches_all_active_selections():
+    """Selections AND across attributes, OR within a list; empty list = no constraint."""
+    attrs = pl.DataFrame(
+        {
+            "UserID": [1, 2, 3, 4],
+            "AuthProvider": ["none", "simple", "simple", "none"],
+            "container_bucket": ["1-5", "21-50", "1-5", "200+"],
+        }
+    )
+
+    ids = filter_installs(attrs, {"AuthProvider": ["simple"], "container_bucket": ["1-5"]})
+    assert sorted(ids.to_list()) == [3]
+
+    ids_or = filter_installs(attrs, {"AuthProvider": ["simple", "none"]})
+    assert sorted(ids_or.to_list()) == [1, 2, 3, 4]
+
+    ids_none = filter_installs(attrs, {"AuthProvider": [], "container_bucket": ["1-5"]})
+    assert sorted(ids_none.to_list()) == [1, 3]
+
+
+def test_version_adoption_keeps_top_n_and_buckets_rest_as_other():
+    """Weekly install share per version; non-top versions collapse into 'Other'."""
+    df = pl.DataFrame(
+        {
+            "UserID": [1, 2, 3, 4, 5],
+            "current_week": [0, 0, 0, 0, 0],
+            "Version": ["v1", "v1", "v2", "v2", "v3"],
+        }
+    )
+
+    out = calculate_version_adoption(df, top_n=2)
+    by_version = {r["version"]: r for r in out.iter_rows(named=True)}
+
+    assert set(by_version) == {"v1", "v2", "Other"}
+    assert by_version["v1"]["installs"] == 2
+    assert abs(by_version["v1"]["share"] - 0.4) < 1e-9
+    assert by_version["Other"]["installs"] == 1
+    assert abs(by_version["Other"]["share"] - 0.2) < 1e-9
+    assert "week_date" in out.columns
+
+
+def test_new_installs_counts_first_ever_launch_week():
+    """New installs = installs whose first-ever launch falls in that week; launches count all."""
+    starts = pl.DataFrame(
+        {
+            "UserID": [1, 1, 2, 3, 3],
+            "CreatedAt": [_dt(3), _dt(10), _dt(10), _dt(10), _dt(10)],
+        }
+    )
+
+    out = calculate_new_installs(starts)
+    weeks = sorted(out["week"].to_list())
+    assert len(weeks) == 2
+    early, late = weeks
+
+    def row(w):
+        return out.filter(pl.col("week") == w).row(0, named=True)
+
+    assert row(early)["new_installs"] == 1  # user 1
+    assert row(late)["new_installs"] == 2  # users 2 and 3 (user 1 already counted)
+    assert row(late)["launches"] == 4  # user1 + user2 + user3 x2
+    assert row(late)["active_installs"] == 3
+    assert "week_date" in out.columns
+
+
+def test_deployment_scale_distribution_is_ordered_with_shares():
+    attrs = pl.DataFrame(
+        {
+            "UserID": [1, 2, 3, 4],
+            "container_bucket": ["21-50", "1-5", "1-5", "0"],
+        }
+    )
+
+    out = calculate_deployment_scale(attrs)
+    assert out["container_bucket"].to_list() == ["0", "1-5", "21-50"]
+    by_bucket = {r["container_bucket"]: r for r in out.iter_rows(named=True)}
+    assert by_bucket["1-5"]["installs"] == 2
+    assert abs(by_bucket["1-5"]["share"] - 0.5) < 1e-9
+
+
+def test_auth_mix_weekly_share_by_provider():
+    df = pl.DataFrame(
+        {
+            "UserID": [1, 2, 3],
+            "current_week": [0, 0, 0],
+            "AuthProvider": ["none", "none", "simple"],
+        }
+    )
+
+    out = calculate_auth_mix(df)
+    by_auth = {r["AuthProvider"]: r for r in out.iter_rows(named=True)}
+    assert by_auth["none"]["installs"] == 2
+    assert abs(by_auth["none"]["share"] - 2 / 3) < 1e-9
+    assert abs(by_auth["simple"]["share"] - 1 / 3) < 1e-9
+    assert "week_date" in out.columns
+
+
+def test_concurrent_clients_averages_per_install_peaks():
+    """Per install take the weekly peak Clients, then average those peaks across installs."""
+    df = pl.DataFrame(
+        {
+            "UserID": [1, 1, 2],
+            "current_week": [0, 0, 0],
+            "Clients": [1, 3, 2],
+        }
+    )
+
+    out = calculate_concurrent_clients(df)
+    wk0 = out.filter(pl.col("current_week") == 0).row(0, named=True)
+    assert abs(wk0["avg_clients"] - 2.5) < 1e-9  # peaks 3 and 2
+    assert wk0["max_clients"] == 3
+    assert "week_date" in out.columns
+
+
+def test_feature_adoption_weekly_share_per_flag_treats_null_as_off():
+    df = pl.DataFrame(
+        {
+            "UserID": [1, 2],
+            "current_week": [0, 0],
+            "HasActions": [True, False],
+            "HasHostname": [False, False],
+            "HasCustomAddress": [False, False],
+            "HasCustomBase": [False, False],
+            "HasShell": [None, True],  # null (old data) must count as not adopted
+        }
+    )
+
+    out = calculate_feature_adoption(df)
+    by_feature = {r["feature"]: r for r in out.iter_rows(named=True)}
+    assert abs(by_feature["HasActions"]["adoption"] - 0.5) < 1e-9
+    assert abs(by_feature["HasShell"]["adoption"] - 0.5) < 1e-9  # only user 2
+    assert "week_date" in out.columns
+
+
+def test_browser_mix_returns_browser_and_os_distributions():
+    attrs = pl.DataFrame(
+        {
+            "UserID": [1, 2, 3],
+            "browser_family": ["Chrome", "Chrome", "Firefox"],
+            "os_family": ["Windows", "macOS", "Windows"],
+        }
+    )
+
+    browser_df, os_df = calculate_browser_mix(attrs)
+    b = {r["browser_family"]: r for r in browser_df.iter_rows(named=True)}
+    o = {r["os_family"]: r for r in os_df.iter_rows(named=True)}
+    assert b["Chrome"]["installs"] == 2
+    assert abs(b["Chrome"]["share"] - 2 / 3) < 1e-9
+    assert o["Windows"]["installs"] == 2
+    assert abs(o["macOS"]["share"] - 1 / 3) < 1e-9

--- a/notebooks/tests/test_data_loader.py
+++ b/notebooks/tests/test_data_loader.py
@@ -1,0 +1,107 @@
+"""Tests for data loading, identity construction, and identity quality."""
+
+from datetime import UTC, datetime
+
+import polars as pl
+from data_loader import (
+    calculate_identity_quality,
+    load_and_process_data,
+    load_start_beacons,
+)
+
+
+def _ts(*days: int) -> pl.Series:
+    return pl.Series(
+        "CreatedAt",
+        [datetime(2024, 1, d, tzinfo=UTC) for d in days],
+        dtype=pl.Datetime("ns", "UTC"),
+    )
+
+
+def _write_day(path, *, names, created, server_ids, **cols):
+    data = {
+        "Name": names,
+        "CreatedAt": created,
+        "ServerID": pl.Series(server_ids, dtype=pl.String),
+    }
+    data.update(cols)
+    pl.DataFrame(data).write_parquet(path)
+
+
+def test_load_keeps_events_with_descriptive_columns_and_stable_identity(tmp_path):
+    """Events load keeps charting columns, drops raw identity/dead columns, builds UserID.
+
+    A 'start' row is excluded; rows without a ServerID fall back to RemoteIP and are
+    flagged id_from_ip (two sharing an IP get one UserID); a file with an extra column
+    (HasShell drift) is tolerated; an always-dead column (RemoteClients) is dropped.
+    """
+    _write_day(
+        tmp_path / "day-2024-01-01.parquet",
+        names=["events", "events", "start"],
+        created=_ts(1, 2, 3),
+        server_ids=["srv-A", "", "srv-A"],
+        RemoteIP=["10.0.0.1", "10.0.0.2", "10.0.0.1"],
+        Version=["v1", "v1", "v1"],
+        RunningContainers=[5, 9, 5],
+        RemoteClients=[0, 0, 0],  # dead column -> must be dropped
+    )
+    _write_day(
+        tmp_path / "day-2024-01-02.parquet",
+        names=["events"],
+        created=_ts(4),
+        server_ids=pl.Series([None], dtype=pl.String),
+        RemoteIP=["10.0.0.2"],
+        Version=["v2"],
+        RunningContainers=[2],
+        HasShell=[True],  # newer-file column -> must be kept (null for old files)
+    )
+
+    df = load_and_process_data(str(tmp_path / "day-*.parquet"))
+
+    assert df.height == 3
+    assert (df["Name"] == "events").all()
+    for kept in ("Version", "RunningContainers", "HasShell", "UserID", "id_from_ip"):
+        assert kept in df.columns
+    for dropped in ("RemoteIP", "ServerID", "RemoteClients"):
+        assert dropped not in df.columns
+    assert df["id_from_ip"].sum() == 2
+    assert df.filter(pl.col("id_from_ip"))["UserID"].n_unique() == 1
+
+
+def test_load_start_beacons_returns_launch_events_with_identity(tmp_path):
+    """Start beacons are loaded separately with a UserID for new-install analysis."""
+    _write_day(
+        tmp_path / "day-2024-01-01.parquet",
+        names=["start", "events", "start"],
+        created=_ts(1, 2, 3),
+        server_ids=["srv-A", "srv-B", "srv-A"],
+        RemoteIP=["10.0.0.1", "10.0.0.2", "10.0.0.1"],
+    )
+
+    starts = load_start_beacons(str(tmp_path / "day-*.parquet"))
+
+    assert starts.height == 2  # only the two 'start' rows
+    assert {"UserID", "CreatedAt"}.issubset(starts.columns)
+    assert starts["UserID"].n_unique() == 1  # both starts are srv-A
+
+
+def test_identity_quality_reports_ip_derived_share():
+    """Report what fraction of rows and distinct users were identified by IP fallback.
+
+    Users 10 and 30 fall back to RemoteIP (no ServerID); user 20 has a ServerID.
+    """
+    df = pl.DataFrame(
+        {
+            "UserID": [10, 10, 20, 30, 20],
+            "id_from_ip": [True, True, False, True, False],
+        }
+    )
+
+    q = calculate_identity_quality(df)
+
+    assert q["ip_rows"] == 3
+    assert q["total_rows"] == 5
+    assert abs(q["ip_row_pct"] - 0.6) < 1e-9
+    assert q["ip_users"] == 2
+    assert q["total_users"] == 3
+    assert abs(q["ip_user_pct"] - 2 / 3) < 1e-9

--- a/notebooks/tests/test_engagement_analysis.py
+++ b/notebooks/tests/test_engagement_analysis.py
@@ -1,0 +1,28 @@
+"""Tests for engagement analysis metrics."""
+
+import polars as pl
+from engagement_analysis import calculate_stickiness_metrics
+
+
+def test_mau_counts_distinct_users_over_trailing_four_weeks():
+    """MAU must be distinct users across the trailing 4 weeks, not max weekly WAU.
+
+    A, B active wk0; C wk1; D wk2; A again wk3. MAU(wk3) spans weeks 0-3 and must
+    count {A, B, C, D} = 4. The old rolling_max(WAU) approximation would report 2.
+    """
+    df = pl.DataFrame(
+        {
+            "UserID": [1, 2, 3, 4, 1],
+            "current_week": [0, 0, 1, 2, 3],
+        }
+    )
+
+    stickiness, stats = calculate_stickiness_metrics(df)
+
+    by_week = {row["current_week"]: row["mau"] for row in stickiness.iter_rows(named=True)}
+    assert by_week == {0: 2, 1: 3, 2: 4, 3: 4}
+    assert stats["current_mau"] == 4
+
+    wk3 = stickiness.filter(pl.col("current_week") == 3)
+    assert wk3["wau"][0] == 1
+    assert abs(wk3["stickiness_ratio"][0] - 0.25) < 1e-9

--- a/notebooks/visualizations.py
+++ b/notebooks/visualizations.py
@@ -259,9 +259,9 @@ def display_stickiness_analysis(stickiness_df: pl.DataFrame, summary_stats: dict
         fig_wau_mau.add_trace(
             go.Scatter(
                 x=stickiness_df["week_date"],
-                y=stickiness_df["mau_rolling_max"],
+                y=stickiness_df["mau"],
                 mode="lines+markers",
-                name="MAU (4-week rolling)",
+                name="MAU (4-week distinct)",
                 line=dict(color="green"),
             )
         )
@@ -389,3 +389,166 @@ def display_cohort_engagement_analysis(cohort_engagement_df: pl.DataFrame) -> No
                 "Week 4 Avg Events",
                 f"{week_4_engagement['avg_events_per_user'][0]:.2f}",
             )
+
+
+def display_new_installs_analysis(new_installs: pl.DataFrame) -> None:
+    """Display new installs and launch volume derived from start beacons."""
+    st.header("New Installs & Launches")
+    st.caption("Derived from `start` (app-launch) beacons — a cleaner signal than events.")
+
+    recent = new_installs.tail(1)
+    col1, col2 = st.columns(2)
+    with col1:
+        st.metric("New Installs (Last Week)", f"{recent['new_installs'][0]:,}")
+    with col2:
+        st.metric("Launches (Last Week)", f"{recent['launches'][0]:,}")
+
+    pdf = new_installs.to_pandas()
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            x=pdf["week_date"],
+            y=pdf["new_installs"],
+            name="New Installs",
+            marker_color="rgba(99, 110, 250, 0.7)",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=pdf["week_date"],
+            y=pdf["active_installs"],
+            name="Active Installs",
+            mode="lines",
+            line=dict(color="rgba(0, 204, 150, 0.9)"),
+        )
+    )
+    fig.update_layout(
+        title="New Installs vs Active Installs per Week",
+        xaxis_title="Week",
+        yaxis_title="Installs",
+        hovermode="x unified",
+    )
+    st.plotly_chart(fig, width="stretch")
+
+
+def display_version_adoption_analysis(version_adoption: pl.DataFrame) -> None:
+    """Display version adoption share over time as a stacked area chart."""
+    st.header("Version Adoption")
+
+    fig = px.area(
+        version_adoption.to_pandas(),
+        x="week_date",
+        y="share",
+        color="version",
+        title="Share of Active Installs by Version",
+        labels={"week_date": "Week", "share": "Share of Installs", "version": "Version"},
+    )
+    fig.update_yaxes(tickformat=".0%")
+    st.plotly_chart(fig, width="stretch")
+
+
+def display_deployment_scale_analysis(scale: pl.DataFrame) -> None:
+    """Display the distribution of installs by deployment size (running containers)."""
+    st.header("Deployment Scale")
+    st.caption("Installs grouped by number of running containers (latest report per install).")
+
+    fig = px.bar(
+        scale.to_pandas(),
+        x="container_bucket",
+        y="installs",
+        title="Installs by Deployment Size",
+        labels={"container_bucket": "Running Containers", "installs": "Installs"},
+    )
+    st.plotly_chart(fig, width="stretch")
+
+
+def display_auth_mix_analysis(auth_mix: pl.DataFrame) -> None:
+    """Display auth-provider share over time as a stacked area chart."""
+    st.header("Authentication Mix")
+
+    fig = px.area(
+        auth_mix.to_pandas(),
+        x="week_date",
+        y="share",
+        color="AuthProvider",
+        title="Share of Active Installs by Auth Provider",
+        labels={"week_date": "Week", "share": "Share of Installs", "AuthProvider": "Auth Provider"},
+    )
+    fig.update_yaxes(tickformat=".0%")
+    st.plotly_chart(fig, width="stretch")
+
+
+def display_concurrent_clients_analysis(clients: pl.DataFrame) -> None:
+    """Display average and peak concurrent browser clients per install over time."""
+    st.header("Concurrent Clients")
+
+    pdf = clients.to_pandas()
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=pdf["week_date"],
+            y=pdf["avg_clients"],
+            name="Avg peak clients / install",
+            mode="lines+markers",
+            line=dict(color="blue"),
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=pdf["week_date"],
+            y=pdf["max_clients"],
+            name="Max clients (any install)",
+            mode="lines",
+            line=dict(color="orange", dash="dot"),
+        )
+    )
+    fig.update_layout(
+        title="Concurrent Browser Clients per Install",
+        xaxis_title="Week",
+        yaxis_title="Clients",
+        hovermode="x unified",
+    )
+    st.plotly_chart(fig, width="stretch")
+
+
+def display_feature_adoption_analysis(feature_adoption: pl.DataFrame) -> None:
+    """Display feature-flag adoption over time as a multi-line chart."""
+    st.header("Feature Adoption")
+
+    fig = px.line(
+        feature_adoption.to_pandas(),
+        x="week_date",
+        y="adoption",
+        color="feature",
+        title="Share of Active Installs with Each Feature Enabled",
+        labels={"week_date": "Week", "adoption": "Adoption", "feature": "Feature"},
+    )
+    fig.update_traces(mode="lines+markers")
+    fig.update_yaxes(tickformat=".0%")
+    st.plotly_chart(fig, width="stretch")
+
+
+def display_browser_mix_analysis(browser_df: pl.DataFrame, os_df: pl.DataFrame) -> None:
+    """Display browser-family and OS-family distributions side by side."""
+    st.header("Browser & OS Mix")
+    st.caption("Latest reported user agent per install.")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        fig_b = px.bar(
+            browser_df.to_pandas(),
+            x="browser_family",
+            y="installs",
+            title="By Browser",
+            labels={"browser_family": "Browser", "installs": "Installs"},
+        )
+        st.plotly_chart(fig_b, width="stretch")
+    with col2:
+        fig_o = px.bar(
+            os_df.to_pandas(),
+            x="os_family",
+            y="installs",
+            title="By OS",
+            labels={"os_family": "OS", "installs": "Installs"},
+        )
+        st.plotly_chart(fig_o, width="stretch")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.3",
     "ruff>=0.15.14",
     "ty>=0.0.39",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -120,6 +120,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -135,6 +136,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.14" },
     { name = "ty", specifier = ">=0.0.39" },
 ]
@@ -194,6 +196,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -393,6 +404,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -467,6 +487,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403, upload-time = "2024-05-10T15:36:17.36Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Reworks the Dozzle analytics dashboard for performance, correctness, and breadth — surfacing telemetry that was collected but never charted.

### Performance & correctness
- **Lazy loading + caching:** load via `scan_parquet` with an explicit schema (predicate/projection pushdown, tolerates the `HasShell` schema drift, auto-drops dead columns). Results are cached so reruns no longer re-scan all ~690 daily parquet files on every widget interaction.
- **Stickiness fix:** MAU is now a true trailing-4-week distinct-user count instead of `rolling_max(WAU)`. On real data this corrects mean stickiness from an implausible **~0.93 → ~0.52**.
- **Identity transparency:** flags `id_from_ip` and shows what fraction of installs rely on the unstable RemoteIP fallback (no ServerID), since those distort retention/churn.

### New analytics (from previously dropped/ignored columns)
Version adoption · new installs & launches (from `start` beacons) · deployment scale · auth mix · concurrent clients · feature-flag adoption · browser/OS mix.

- **Segmentation:** a sidebar re-slices every chart by install attributes (version, auth, deployment size, browser, OS, required features). It filters by install membership so each install's full history — and thus cohort timing — is preserved.
- **Layout:** restructured into tabs; a data-quality note flags the dead telemetry columns (`ServerVersion`, `SubCommand`, `Mode/swarm`, `RemoteAgents/Clients`, `FilterLength`, `IsSwarmMode`) that are empty across all history.

### Tooling & tests
- Added `pytest`; **14 tests** cover the loader contract, identity quality, UA parsing priority, install attributes, segmentation, and all new analysis functions.
- `ruff`, `ruff format`, and `ty` all clean.

## Verification
- All analysis functions exercised on ~11M real rows; numbers sane (Chrome 56%, Windows 39%, ~10.5k new installs/wk, segmentation by auth → 12.5k installs).
- Ran under `-W error::DeprecationWarning` to confirm the `is_in`/`implode` fix.
- `import dashboard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)